### PR TITLE
Resolve missing tools on $PATH

### DIFF
--- a/install_impl.sh
+++ b/install_impl.sh
@@ -225,11 +225,8 @@ function install_shell {
     local shell_path
     shell_path="$(which "$SHELL_TO_INSTALL")"
 
-    local current_user_name
-    current_user_name="$(id -u -n)"
-
     # Then configure it as user's default shell
-    sudo chsh -s "$shell_path" "$current_user_name"
+    sudo chsh -s "$shell_path" "$CURRENT_USER_NAME"
 }
 
 ###
@@ -307,6 +304,8 @@ function install_dotfiles {
             return 2
         fi
         [ "$VERBOSE" = true ] && success "Successfully installed brew"
+        # Relogin to apply changes in $PATH
+        su - "$CURRENT_USER_NAME"
     fi
 
     if ! install_git; then
@@ -320,6 +319,8 @@ function install_dotfiles {
         return 2
     fi
     [ "$VERBOSE" = true ] && success "Successfully installed $SHELL_TO_INSTALL"
+    # Relogin to apply changes in $PATH
+    su - "$CURRENT_USER_NAME"
 
     if ! prepare_dotfiles_environment; then
         error "Failed preparing dotfiles environment"
@@ -376,6 +377,8 @@ function set_globals {
         error "Couldn't determine download tool, aborting"
         return 1
     fi
+
+    CURRENT_USER_NAME="$(id -u -n)"
 
     if root_user; then
         ROOT_USER=true

--- a/install_impl.sh
+++ b/install_impl.sh
@@ -288,6 +288,8 @@ function install_brew {
         return 1
     fi
 
+    [ "$VERBOSE" = true ] && info "Adding brew to $PATH by appending to the user profile $SHELL_USER_PROFILE"
+
     if ! echo "eval \"$($BREW_LOCATION_RESOLVING_CMD)\"" >>"$SHELL_USER_PROFILE"; then
         return 2
     fi


### PR DESCRIPTION
Tools such as brew need to be manually appended to $PATH, and also to the shell's user profile, in order to be available.
This PR handles that, as well as requesting a full relogin to the same running user after installing and configuring the shell.