### PR TITLE
Handle multiple existing gpg keys

### DIFF
--- a/install-impl.sh
+++ b/install-impl.sh
@@ -289,7 +289,9 @@ function _install_gpg_client {
 
 ###
 # Ensures a GPG key exist in order to be able to sign git commits in the future (and maybe do other stuff).
-# If the "default" key is not available, a new one is created instead and will be used in all managed dotfiles.
+# If a key is not already available, a new one is created instead and will be used in all managed dotfiles.
+# Otherwise, the user is asked whether to reuse an existing key, and if so which one.
+# The user can also decide to create a new one nevertheless.
 # The script requires some interactivity.
 ###
 function ensure_gpg_key_exist {
@@ -300,13 +302,32 @@ function ensure_gpg_key_exist {
     fi
     success "Successfully installed gpg client"
 
-    info "Checking whether expected GPG key ($ACTIVE_GPG_SIGNING_KEY) is already available"
-    if gpg --list-secret-keys --keyid-format LONG | grep -q "$ACTIVE_GPG_SIGNING_KEY"; then
-        info "Expected GPG key is already available!"
-        return 0
-    fi
+    if gpg --list-secret-keys --keyid-format LONG | grep -q "sec"; then
+        info "GPG keys already available"
 
-    warning "Expected GPG key ($ACTIVE_GPG_SIGNING_KEY) is not available, creating a new one"
+        info "Would you like to reuse one of the available keys?"
+        local answer
+        select answer in "Yes" "No"; do
+            case $answer in
+            [Yy]*)
+                local available_keys
+                mapfile -t available_keys < <(gpg --list-secret-keys --keyid-format LONG | tr -s " " | awk -F"[ /]" '/^sec/ { print $3 }')
+
+                info "Select the key to reuse:"
+                local selected_key
+                select selected_key in "${available_keys[@]}"; do
+                    warning "Using $selected_key as the GPG key"
+                    ACTIVE_GPG_SIGNING_KEY="$selected_key"
+                    return 0
+                done
+                ;;
+            [Nn]*)
+                warning "Creating a new GPG key"
+                break
+                ;;
+            esac
+        done
+    fi
 
     local new_gpg_key
     if ! _create_new_gpg_key new_gpg_key; then
@@ -315,7 +336,7 @@ function ensure_gpg_key_exist {
     fi
     success "Successfully created a new GPG key"
 
-    ACTIVE_GPG_SIGNING_KEY="${new_gpg_key}"
+    ACTIVE_GPG_SIGNING_KEY="$new_gpg_key"
     return 0
 }
 
@@ -497,10 +518,8 @@ function set_globals {
 
     if [[ "$WORK_ENVIRONMENT" == true ]]; then
         ACTIVE_EMAIL="$WORK_EMAIL"
-        ACTIVE_GPG_SIGNING_KEY="$WORK_GPG_SIGNING_KEY"
     else
         ACTIVE_EMAIL="$PERSONAL_EMAIL"
-        ACTIVE_GPG_SIGNING_KEY="$PERSONAL_GPG_SIGNING_KEY"
     fi
 }
 
@@ -623,9 +642,7 @@ function _set_personal_info_defaults {
     GITHUB_USERNAME="MrPointer"
     FULL_NAME="Timor Gruber"
     PERSONAL_EMAIL="timor.gruber@gmail.com"
-    PERSONAL_GPG_SIGNING_KEY=D8B3170598131C15
     WORK_EMAIL="timor.gruber@solaredge.com"
-    WORK_GPG_SIGNING_KEY=90BBCCC1DDED66C4
 }
 
 ###

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -250,7 +250,7 @@ function _create_new_gpg_key {
     declare -n created_key="${1:?}"
 
     gpg --expert --full-gen-key || return 1
-    created_key="$(gpg --list-secret-keys --keyid-format LONG | tr -s " " | awk -F"[ /]" '/^sec/ { print $3 }')" || return 2
+    created_key="$(gpg --list-secret-keys --keyid-format LONG | tr -s " " | awk -F"[ /]" '/^sec/ { print $3 }' | tail -n1)" || return 2
     return 0
 }
 

--- a/private_dot_sedg/private_bin/run_once_after_configure-vpn-fix-tool.sh.tmpl
+++ b/private_dot_sedg/private_bin/run_once_after_configure-vpn-fix-tool.sh.tmpl
@@ -67,35 +67,38 @@ VPN_FIX_TOOL_SUDO_CONTENT
 }
 
 function _link_system_files {
-    sudo ln -s "$SEDG_FIX_VPN_EXECUTABLE_PATH" "$FIX_TOOL_LINK_TARGET"
+    sudo ln -sf "$SEDG_FIX_VPN_EXECUTABLE_PATH" "$FIX_TOOL_LINK_TARGET"
+}
+
+function _migrate_old_config {
+    sudo rm -rf "$OLD_FIX_TOOL_SUDOERS_FILE"
+    sudo rm -rf "${OLD_FIX_TOOL_LINK_TARGETS[@]}"
 }
 
 ###
 # Configures vpn fix-tool
 ###
 function configure_vpn_fix_tool {
+    info "Migrating old config (if any)"
+    if ! _migrate_old_config; then
+        error "Failed migrating old config"
+        return 1
+    fi
+    success "Successfully migrated old config"
+
     info "Linking vpn fix-tool to system dirs"
     if ! _link_system_files; then
         error "Failed linking vpn fix-tool to system dirs"
-        return 1
+        return 2
     fi
     success "Successfully linked vpn fix-tool"
 
     info "Enabling sudo access for the vpn fix-tool"
     if ! _enable_sudo_access; then
         error "Failed enabling sudo access for the vpn fix-tool"
-        return 2
+        return 3
     fi
     success "Successfully enabled sudo access for the vpn fix-tool"
-    return 0
-}
-
-###
-# Checks whether the vpn fix-tool has already been configured
-###
-function vpn_fix_tool_already_configured {
-    [[ -f "$FIX_TOOL_LINK_TARGET" ]] || return 1
-    [[ -f "$FIX_TOOL_SUDOERS_FILE" ]] || return 1
     return 0
 }
 
@@ -114,8 +117,11 @@ function set_globals {
 ###
 function set_defaults {
     FIX_TOOL_LINK_TARGET_DIR="/usr/local/bin"
+    OLD_FIX_TOOL_LINK_TARGETS=("$FIX_TOOL_LINK_TARGET_DIR/vpn-up" "$FIX_TOOL_LINK_TARGET_DIR/vpn-down")
+
     SUDOERS_DIR="/etc/sudoers.d"
     FIX_TOOL_SUDOERS_FILE="$SUDOERS_DIR/vpn-fix-tool"
+    OLD_FIX_TOOL_SUDOERS_FILE="$SUDOERS_DIR/vpn-mtu"
 }
 
 ###
@@ -150,11 +156,6 @@ function main {
     if ! set_globals; then
         error "Failed setting global variables, aborting"
         return 2
-    fi
-
-    if vpn_fix_tool_already_configured; then
-        # Do nothing and exit silently
-        return 0
     fi
 
     info "Configuring vpn fix-tool"


### PR DESCRIPTION
User gets to decide whether to reuse a gpg key, and if so, which one.
It allows for friendlier installations on partially-setup machines,
or simply ones where the gpg keys are generated from a different source.  

Also, when creating a new key, this key will be used if there are already some existing keys (fixing a previous bug).