### PR TITLE
Support Homebrew installations on multi-user machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following options can be passed to the command above to customize the instal
 | `--brew-shell`                | Install shell using `brew`. By default it's installed with system's package manager                         |
 | `--prefer-package-manager`    | Prefer installing tools with system's package manager rather than brew (Doesn't apply for Mac)              |
 | `--package-manager=[manager]` | Package manager to use for installing prerequisites                                                         |
+| `--multi-user-system`         | Take into account that the system is used by multiple users                                                 |
 
 To add options to the install command above, append it after the last closing parentheses `)`, like so:  
 `bash -c "$(curl -fsSL https://raw.githubusercontent.com/MrPointer/dotfiles/main/install.sh) --verbose"`
@@ -57,7 +58,7 @@ by making sure everything is available, and only then proceed with the actual in
 
 The main installation driver script is written in "Pure" shell,
 guaranteed to work on almost all systems, even the strangest ones.  
-It checks whether `bash` is available, trying to install it if not. 
+It checks whether `bash` is available, trying to install it if not.
 The installation utilizes the guessed system package manager, e.g. `apt` for `Debian` systems.  
 If the installation fails for some reason, then the user is prompted to manually install `bash`.  
 After `bash` is properly installed, it's used to execute the actual installation script, written in `bash`.  

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -48,8 +48,8 @@ fi
 {{- end }}
 {{- end -}}
 
-{{ if .data.system.multi_user_system -}}
-alias brew='sudo -Hu {{ .data.system.brew_multi_user }} brew'
+{{ if .system.multi_user_system -}}
+alias brew='sudo -Hu {{ .system.brew_multi_user }} brew'
 {{- end }}
 
 {{ if .personal.work_env -}}

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -48,6 +48,10 @@ fi
 {{- end }}
 {{- end -}}
 
+{{ if .data.system.multi_user_system -}}
+alias brew='sudo -Hu {{ .data.system.brew_multi_user }} brew'
+{{- end }}
+
 {{ if .personal.work_env -}}
 # Load work-generic profile
 source {{ .system.work_generic_dotfiles_profile }}

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -4,13 +4,18 @@ export PATH=$HOME/.local/bin:$HOME/bin:$HOME/.bin:$HOME/bin:/usr/local/bin:$PATH
 export GPG_TTY=$(tty)
 
 BREW_HOME="/home/linuxbrew/.linuxbrew"
+BREW_BINARY="$BREW_HOME"/bin/brew
 
-if [[ -d /home/linuxbrew/ && -f "$BREW_HOME"/bin/brew ]]; then
+if [[ -d /home/linuxbrew/ && -f "$BREW_BINARY" ]]; then
     {{ if (eq .chezmoi.group "devbox") -}}
     export PATH="$PATH:"$BREW_HOME"/bin:"$BREW_HOME"/sbin"
-    {{- else -}}
+    {{- else }}
     # Load (home)brew
-    eval "$("$BREW_HOME"/bin/brew shellenv)"
+    eval "$("$BREW_BINARY" shellenv)"
+    {{- end }}
+    {{- if .system.multi_user_system -}}
+    # Impersonate brew management user
+    alias brew="sudo -Hu {{ .system.brew_multi_user }} $BREW_BINARY"
     {{- end }}
 fi
 
@@ -47,10 +52,6 @@ if [[ -d "/mnt/c/Users/timor.g/AppData/Local/Programs/Microsoft VS Code/bin/" ]]
 fi
 {{- end }}
 {{- end -}}
-
-{{ if .system.multi_user_system -}}
-alias brew='sudo -Hu {{ .system.brew_multi_user }} brew'
-{{- end }}
 
 {{ if .personal.work_env -}}
 # Load work-generic profile

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -108,7 +108,11 @@ zstyle ':completion:*' menu select
 mkdir -p ~/.zfunc &>/dev/null
 fpath+=~/.zfunc
 
+{{ if .system.multi_user_system -}}
+autoload -U +X compinit && compinit -u
+{{- else -}}
 autoload -U +X compinit && compinit
+{{- end }}
 autoload -U +X bashcompinit && bashcompinit
 
 if hash pipx &>/dev/null; then

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -430,6 +430,10 @@ function install_brew {
                     error "Failed adding user '$BREW_USER_ON_MULTI_USER_SYSTEM' to sudo group"
                     return 1
                 fi
+                if ! echo "$BREW_USER_ON_MULTI_USER_SYSTEM ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers >/dev/null; then
+                    error "Failed adding user '$BREW_USER_ON_MULTI_USER_SYSTEM' to passwordless-sudoers"
+                    return 1
+                fi
             else
                 if ! "${create_brew_user_cmd[@]}"; then
                     error "Failed creating user '$BREW_USER_ON_MULTI_USER_SYSTEM' for brew"

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -487,13 +487,6 @@ function install_dotfiles_manager {
 # Install dotfiles. This is the main "driver" function.
 ###
 function install_dotfiles {
-    info "Installing dotfiles manager ($DOTFILES_MANAGER)"
-    if ! install_dotfiles_manager; then
-        error "Failed installing dotfiles manager ($DOTFILES_MANAGER)"
-        return 1
-    fi
-    success "Successfully installed dotfiles manager, $DOTFILES_MANAGER"
-
     if [[ "$INSTALL_BREW" == true ]]; then
         info "Installing brew"
         if ! install_brew; then
@@ -516,6 +509,13 @@ function install_dotfiles {
         return 3
     fi
     success "Successfully ensured a GPG key exists"
+
+    info "Installing dotfiles manager ($DOTFILES_MANAGER)"
+    if ! install_dotfiles_manager; then
+        error "Failed installing dotfiles manager ($DOTFILES_MANAGER)"
+        return 1
+    fi
+    success "Successfully installed dotfiles manager, $DOTFILES_MANAGER"
 
     info "Preparing dotfiles environment"
     if ! prepare_dotfiles_environment; then

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -447,9 +447,9 @@ function install_dotfiles_manager {
     local installation_failed=false
 
     if [[ "$DOWNLOAD_TOOL" == "curl" ]]; then
-        ! sh -c "$(curl -fsLS git.io/chezmoi)" && installation_failed=true
+        ! sh -c "$(curl -fsLS get.chezmoi.io)" && installation_failed=true
     elif [[ "$DOWNLOAD_TOOL" == "wget" ]]; then
-        ! sh -c "$(wget -qO- git.io/chezmoi)" && installation_failed=true
+        ! sh -c "$(wget -qO- get.chezmoi.io)" && installation_failed=true
     fi
 
     if [[ "$installation_failed" == true ]]; then

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -419,7 +419,7 @@ function install_brew {
     if [[ "$MULTI_USER_SYSTEM" == true ]]; then
         if ! id "$BREW_USER_ON_MULTI_USER_SYSTEM" &>/dev/null; then
             info "Creating user '$BREW_USER_ON_MULTI_USER_SYSTEM' for brew"
-            local create_brew_user_cmd=(useradd -m "$BREW_USER_ON_MULTI_USER_SYSTEM")
+            local create_brew_user_cmd=(useradd -m -p "" "$BREW_USER_ON_MULTI_USER_SYSTEM")
             if [[ "$ROOT_USER" == false ]]; then
                 create_brew_user_cmd=(sudo "${create_brew_user_cmd[@]}")
                 if ! "${create_brew_user_cmd[@]}"; then

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -422,21 +422,28 @@ function install_brew {
             local create_brew_user_cmd=(useradd -m "$BREW_USER_ON_MULTI_USER_SYSTEM")
             if [[ "$ROOT_USER" == false ]]; then
                 create_brew_user_cmd=(sudo "${create_brew_user_cmd[@]}")
-            fi
-            if ! "${create_brew_user_cmd[@]}"; then
-                error "Failed creating user '$BREW_USER_ON_MULTI_USER_SYSTEM' for brew"
-                return 1
+                if ! "${create_brew_user_cmd[@]}"; then
+                    error "Failed creating user '$BREW_USER_ON_MULTI_USER_SYSTEM' for brew"
+                    return 1
+                fi
+                if ! sudo usermod -aG sudo "$BREW_USER_ON_MULTI_USER_SYSTEM"; then
+                    error "Failed adding user '$BREW_USER_ON_MULTI_USER_SYSTEM' to sudo group"
+                    return 1
+                fi
+            else
+                if ! "${create_brew_user_cmd[@]}"; then
+                    error "Failed creating user '$BREW_USER_ON_MULTI_USER_SYSTEM' for brew"
+                    return 1
+                fi
             fi
         fi
 
         if ! sudo -Hu "$BREW_USER_ON_MULTI_USER_SYSTEM" \
             bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
-            error "Failed installing brew"
             return 2
         fi
     else
         if ! bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
-            error "Failed installing brew"
             return 2
         fi
     fi
@@ -725,7 +732,7 @@ function _set_package_management_defaults {
     BREW_LOCATION_RESOLVING_CMD="$DEFAULT_BREW_PATH shellenv"
     BREW_AVAILABLE=false
     BREW_INSTALLED_DOTFILES_MANAGER=false
-    BREW_USER_ON_MULTI_USER_SYSTEM="linuxbrew"
+    BREW_USER_ON_MULTI_USER_SYSTEM="linuxbrew-manager"
 }
 
 function _set_shell_defaults {

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -23,6 +23,7 @@ Options:
   --no-brew                         Don't install brew (Homebrew)
   --prefer-package-manager          Prefer installing tools with system's package manager rather than brew (Doesn't apply for Mac)
   --package-manager=[manager]       Package manager to use for installing prerequisites
+  --multi-user-system               Take into account that the system is used by multiple users
 -----------------------------------------------------"
 DOTFILES_INSTALL_IMPL_USAGE
 }

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -108,9 +108,14 @@ function root_user {
     ((current_uid == 0))
 }
 
-function set_brew_alias {
-    [[ "$MULTI_USER_SYSTEM" == "false" ]] && return 0
-    alias brew="sudo -Hu $BREW_USER_ON_MULTI_USER_SYSTEM brew"
+function brew {
+    if [[ "$MULTI_USER_SYSTEM" == "false" ]]; then
+        brew "$@"
+        return $?
+    else
+        sudo -Hu "$BREW_USER_ON_MULTI_USER_SYSTEM" "$DEFAULT_BREW_PATH" "$@"
+        return $?
+    fi
 }
 
 function _install_packages_with_brew {
@@ -545,8 +550,6 @@ function install_dotfiles {
         return 3
     fi
     success "Successfully ensured a GPG key exists"
-
-    set_brew_alias
 
     info "Installing dotfiles manager ($DOTFILES_MANAGER)"
     if ! install_dotfiles_manager; then

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -108,6 +108,11 @@ function root_user {
     ((current_uid == 0))
 }
 
+function set_brew_alias {
+    [[ "$MULTI_USER_SYSTEM" == "false" ]] && return 0
+    alias brew="sudo -Hu $BREW_USER_ON_MULTI_USER_SYSTEM brew"
+}
+
 function _install_packages_with_brew {
     local packages=("$@")
 
@@ -541,6 +546,8 @@ function install_dotfiles {
         return 3
     fi
     success "Successfully ensured a GPG key exists"
+
+    set_brew_alias
 
     info "Installing dotfiles manager ($DOTFILES_MANAGER)"
     if ! install_dotfiles_manager; then

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -268,7 +268,7 @@ function prepare_dotfiles_environment {
         printf "%s\n" "[data.system]"
         printf "\t%s\n" "shell = \"$SHELL_TO_INSTALL\""
         printf "\t%s\n" "user = \"$CURRENT_USER_NAME\""
-        printf "\t%s\n" "multi_user_system = \"$MULTI_USER_SYSTEM\""
+        printf "\t%s\n" "multi_user_system = $MULTI_USER_SYSTEM"
         printf "\t%s\n" "brew_multi_user = \"$BREW_USER_ON_MULTI_USER_SYSTEM\""
     } >>"$ENVIRONMENT_TEMPLATE_FILE_PATH"
 

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -456,6 +456,12 @@ function install_brew {
             bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
             return 2
         fi
+
+        local brew_user_profile_file="/home/$BREW_USER_ON_MULTI_USER_SYSTEM/.profile"
+        {
+            # Load (home)brew
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        } | sudo -Hu "$BREW_USER_ON_MULTI_USER_SYSTEM" tee -a "$brew_user_profile_file"
     else
         if ! bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
             return 2

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -428,13 +428,15 @@ function install_brew {
 ###
 function install_dotfiles_manager {
     local dotfiles_manager_bin=""
-    if command -v "$DOTFILES_MANAGER" &>/dev/null || [[ -f "$DOTFILES_MANAGER_STANDALONE_BINARY_PATH" ]]; then
-        info "$DOTFILES_MANAGER already installed, skipping"
-        dotfiles_manager_bin="$(which "$DOTFILES_MANAGER")"
+    if dotfiles_manager_bin="$(command -v "$DOTFILES_MANAGER" &>/dev/null)" && [[ -n "$dotfiles_manager_bin" ]]; then
+        info "$DOTFILES_MANAGER already installed at '$dotfiles_manager_bin', skipping"
     elif [[ "$BREW_AVAILABLE" == true && -e "$DOTFILES_MANAGER_BREW_BINARY_PATH" ]]; then
         info "$DOTFILES_MANAGER already installed with brew, skipping"
         BREW_INSTALLED_DOTFILES_MANAGER=true
         dotfiles_manager_bin="$DOTFILES_MANAGER_BREW_BINARY_PATH/bin/${DOTFILES_MANAGER}"
+    elif [[ -f "$DOTFILES_MANAGER_STANDALONE_BINARY_PATH" && -x "$DOTFILES_MANAGER_STANDALONE_BINARY_PATH" ]]; then
+        info "$DOTFILES_MANAGER already installed at '$DOTFILES_MANAGER_STANDALONE_BINARY_PATH', skipping"
+        dotfiles_manager_bin="$DOTFILES_MANAGER_STANDALONE_BINARY_PATH"
     fi
 
     if [[ -n "$dotfiles_manager_bin" ]]; then

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -467,7 +467,7 @@ function install_brew {
 ###
 function install_dotfiles_manager {
     local dotfiles_manager_bin=""
-    if dotfiles_manager_bin="$(command -v "$DOTFILES_MANAGER" &>/dev/null)"; then
+    if dotfiles_manager_bin="$(command -v "$DOTFILES_MANAGER" 2>/dev/null)"; then
         info "$DOTFILES_MANAGER already installed at '$dotfiles_manager_bin', skipping"
     elif [[ "$BREW_AVAILABLE" == true && -e "$DOTFILES_MANAGER_BREW_BINARY_PATH" ]]; then
         info "$DOTFILES_MANAGER already installed with brew, skipping"
@@ -482,7 +482,6 @@ function install_dotfiles_manager {
     fi
 
     if [[ -n "$dotfiles_manager_bin" ]]; then
-        warning "WTF?"
         APPLY_DOTFILES_CMD=("$dotfiles_manager_bin")
         return 0
     else


### PR DESCRIPTION
After switching to a multi-user machine at work, where some of my colleagues also use Homebrew, there was a need to make sure that the installation process will work for multiple users, as Homebrew is not designed to be used by multiple users.  
The problem is solved by creating a special user to manage Homebrew, and then using `sudo` to impersonate that user when using Homebrew.