### PR TITLE
feat: sedg: customize LD_LIBRARY_PATH in C++ projects

### DIFF
--- a/private_dot_work/private_sedg/zsh/dot_zshenv.tmpl
+++ b/private_dot_work/private_sedg/zsh/dot_zshenv.tmpl
@@ -29,6 +29,10 @@ if command -v jenv &> /dev/null; then
     eval "$(jenv init -)"
 fi
 
+if [[ -d "$(pwd)/builds/x86/Debug/so_conan" ]]; then
+    export LD_LIBRARY_PATH="$(pwd)/builds/x86/Debug/so_conan:$LD_LIBRARY_PATH"
+fi
+
 {{- if (eq .chezmoi.group "devbox") }}
 while IFS='' read -r -d '' file; do
     source "$file"


### PR DESCRIPTION
If the terminal is opened in a C++ project that was built according
to our standards in sedg, customize the LD_LIBRARY_PATH to
automatically contain the build-output folder that contains all
imported shared libraries.