### PR TITLE
feature: remove support for multi-user systems

### DIFF
--- a/.github/workflows/installer-ci.yml
+++ b/.github/workflows/installer-ci.yml
@@ -216,7 +216,6 @@ jobs:
             --install-prerequisites=true \
             --git-clone-protocol=https \
             --work-env=false \
-            --multi-user-system=false
 
       - name: Install expect tool
         run: |

--- a/.github/workflows/installer-ci.yml
+++ b/.github/workflows/installer-ci.yml
@@ -207,14 +207,29 @@ jobs:
           mkdir -p "$HOME/.gnupg"
           chmod 700 "$HOME/.gnupg"
 
+          # Get current branch name for testing with fallbacks
+          # GITHUB_HEAD_REF is set for pull requests, GITHUB_REF for pushes
+          # If both fail, default to main branch to prevent CI failures
+          if [ -n "$GITHUB_HEAD_REF" ]; then
+            CURRENT_BRANCH="$GITHUB_HEAD_REF"
+          elif [ -n "$GITHUB_REF" ]; then
+            CURRENT_BRANCH="${GITHUB_REF#refs/heads/}"
+          else
+            CURRENT_BRANCH="main"
+            echo "Warning: Could not detect branch, defaulting to main"
+          fi
+          echo "Using branch: $CURRENT_BRANCH"
+
           # Run the installer with minimal configuration that shouldn't require interaction
           # We use https as the git clone protocol to avoid SSH key prompts
+          # We use the current branch to test branch-specific changes
           timeout 300 ./dotfiles-installer install \
             --non-interactive \
             --plain \
             --extra-verbose \
             --install-prerequisites=true \
             --git-clone-protocol=https \
+            --git-branch="$CURRENT_BRANCH" \
             --work-env=false \
 
       - name: Install expect tool
@@ -242,12 +257,25 @@ jobs:
           mkdir -p "$HOME/.gnupg"
           chmod 700 "$HOME/.gnupg"
 
-          # Run the expect script with test parameters
+          # Get current branch name for testing with fallbacks
+          # This ensures we test against the same branch as the installer changes
+          if [ -n "$GITHUB_HEAD_REF" ]; then
+            CURRENT_BRANCH="$GITHUB_HEAD_REF"
+          elif [ -n "$GITHUB_REF" ]; then
+            CURRENT_BRANCH="${GITHUB_REF#refs/heads/}"
+          else
+            CURRENT_BRANCH="main"
+            echo "Warning: Could not detect branch, defaulting to main"
+          fi
+          echo "Using branch: $CURRENT_BRANCH"
+
+          # Run the expect script with test parameters and current branch
           installer/test-interactive-gpg.exp \
             "./dotfiles-installer" \
             "test-user@example.com" \
             "Test CI User" \
-            "test-ci-passphrase"
+            "test-ci-passphrase" \
+            "$CURRENT_BRANCH"
 
       - name: Verify Installation Artifacts (if created)
         run: |

--- a/dot_zprofile.tmpl
+++ b/dot_zprofile.tmpl
@@ -17,10 +17,6 @@ if [[ ! -v BREW_LOADED || "$BREW_LOADED" == "false" ]]; then
         # Load (home)brew
         eval "$("$BREW_BINARY" shellenv)"
         {{- end -}}
-        {{ if .system.multi_user_system -}}
-        # Impersonate brew management user
-        alias brew="sudo -Hu {{ .system.brew_multi_user }} $BREW_BINARY"
-        {{- end }}
     fi
 
     BREW_LOADED=true

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -32,10 +32,6 @@ if [[ ! -v BREW_LOADED || "$BREW_LOADED" == "false" ]]; then
         load_brew_env
         {{- end -}}
         {{- end -}}
-        {{- if .system.multi_user_system }}
-        # Impersonate brew management user
-        alias brew="sudo -Hu {{ .system.brew_multi_user }} $BREW_BINARY"
-        {{- end }}
     fi
 
     BREW_LOADED=true

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -26,11 +26,7 @@ zstyle ':completion:*' menu select
 mkdir -p ~/.zfunc &>/dev/null
 fpath+=~/.zfunc
 
-{{ if .system.multi_user_system -}}
-autoload -U +X compinit && compinit -u
-{{- else -}}
 autoload -U +X compinit && compinit
-{{- end }}
 autoload -U +X bashcompinit && bashcompinit
 
 autoload -U select-word-style

--- a/installer/cmd/install.go
+++ b/installer/cmd/install.go
@@ -30,7 +30,7 @@ var (
 	shellName            string
 	installBrew          bool
 	installShellWithBrew bool
-	multiUserSystem      bool
+
 	gitCloneProtocol     string
 	verbose              bool
 	installPrerequisites bool
@@ -243,14 +243,13 @@ func installHomebrew(sysInfo compatibility.SystemInfo, log logger.Logger) (strin
 
 	// Create BrewInstaller using the new API.
 	installer := brew.NewBrewInstaller(brew.Options{
-		SystemInfo:      &sysInfo,
-		Logger:          cliLogger,
-		Commander:       globalCommander,
-		HTTPClient:      globalHttpClient,
-		OsManager:       globalOsManager,
-		Fs:              globalFilesystem,
-		MultiUserSystem: multiUserSystem,
-		DisplayMode:     GetDisplayMode(),
+		SystemInfo:  &sysInfo,
+		Logger:      cliLogger,
+		Commander:   globalCommander,
+		HTTPClient:  globalHttpClient,
+		OsManager:   globalOsManager,
+		Fs:          globalFilesystem,
+		DisplayMode: GetDisplayMode(),
 	})
 
 	log.StartProgress("Checking Homebrew availability")
@@ -466,9 +465,7 @@ func initDotfilesManagerData(dm dotfilesmanager.DotfilesManager) error {
 		LastName:  "Gruber",
 		Email:     "timor.gruber@gmail.com",
 		SystemData: mo.Some(dotfilesmanager.DotfilesSystemData{
-			Shell:           shellName,
-			MultiUserSystem: multiUserSystem,
-			BrewMultiUser:   "linuxbrew-manager",
+			Shell: shellName,
 		}),
 	}
 
@@ -515,11 +512,8 @@ func init() {
 		"Install brew if not already installed")
 	installCmd.Flags().BoolVar(&installShellWithBrew, "install-shell-with-brew", true,
 		"Install shell with brew if not already installed")
-	installCmd.Flags().BoolVar(&multiUserSystem, "multi-user-system", false,
-		"Treat this system as a multi-user system (affects some dotfiles)")
 	installCmd.Flags().StringVar(&gitCloneProtocol, "git-clone-protocol", "https",
 		"Use the given git clone protocol (ssh or https) for git operations")
-
 	installCmd.Flags().BoolVar(&installPrerequisites, "install-prerequisites", false,
 		"Automatically install missing prerequisites")
 
@@ -529,7 +523,6 @@ func init() {
 	viper.BindPFlag("shell", installCmd.Flags().Lookup("shell"))
 	viper.BindPFlag("install-brew", installCmd.Flags().Lookup("install-brew"))
 	viper.BindPFlag("install-shell-with-brew", installCmd.Flags().Lookup("install-shell-with-brew"))
-	viper.BindPFlag("multi-user-system", installCmd.Flags().Lookup("multi-user-system"))
 	viper.BindPFlag("git-clone-protocol", installCmd.Flags().Lookup("git-clone-protocol"))
 
 	viper.BindPFlag("install-prerequisites", installCmd.Flags().Lookup("install-prerequisites"))

--- a/installer/cmd/install.go
+++ b/installer/cmd/install.go
@@ -32,6 +32,7 @@ var (
 	installShellWithBrew bool
 
 	gitCloneProtocol     string
+	gitBranch            string
 	verbose              bool
 	installPrerequisites bool
 )
@@ -427,7 +428,7 @@ func installGpgClient(log logger.Logger) error {
 func setupDotfilesManager(log logger.Logger) error {
 	log.StartProgress("Setting up dotfiles manager")
 
-	dm, err := chezmoi.TryStandardChezmoiManager(log, globalFilesystem, globalOsManager, globalCommander, globalPackageManager, globalHttpClient, GetDisplayMode(), chezmoi.DefaultGitHubUsername, gitCloneProtocol == "ssh")
+	dm, err := chezmoi.TryStandardChezmoiManager(log, globalFilesystem, globalOsManager, globalCommander, globalPackageManager, globalHttpClient, GetDisplayMode(), chezmoi.DefaultGitHubUsername, gitCloneProtocol == "ssh", gitBranch)
 	if err != nil {
 		log.FailProgress("Failed to create dotfiles manager", err)
 		return err
@@ -514,6 +515,9 @@ func init() {
 		"Install shell with brew if not already installed")
 	installCmd.Flags().StringVar(&gitCloneProtocol, "git-clone-protocol", "https",
 		"Use the given git clone protocol (ssh or https) for git operations")
+	installCmd.Flags().StringVar(&gitBranch, "git-branch", "",
+		"Use the given git branch for dotfiles repository operations (defaults to repository's default branch). "+
+			"Useful for testing changes in feature branches or when running in CI/CD pipelines.")
 	installCmd.Flags().BoolVar(&installPrerequisites, "install-prerequisites", false,
 		"Automatically install missing prerequisites")
 
@@ -524,6 +528,7 @@ func init() {
 	viper.BindPFlag("install-brew", installCmd.Flags().Lookup("install-brew"))
 	viper.BindPFlag("install-shell-with-brew", installCmd.Flags().Lookup("install-shell-with-brew"))
 	viper.BindPFlag("git-clone-protocol", installCmd.Flags().Lookup("git-clone-protocol"))
+	viper.BindPFlag("git-branch", installCmd.Flags().Lookup("git-branch"))
 
 	viper.BindPFlag("install-prerequisites", installCmd.Flags().Lookup("install-prerequisites"))
 }

--- a/installer/lib/dotfilesmanager/chezmoi/apply.go
+++ b/installer/lib/dotfilesmanager/chezmoi/apply.go
@@ -23,6 +23,9 @@ func (c *ChezmoiManager) Apply() error {
 	if c.chezmoiConfig.cloneViaSSH {
 		chezmoiApplyCmdArgs = append(chezmoiApplyCmdArgs, "--ssh")
 	}
+	if c.chezmoiConfig.branch != "" {
+		chezmoiApplyCmdArgs = append(chezmoiApplyCmdArgs, "--branch", c.chezmoiConfig.branch)
+	}
 	chezmoiApplyCmdArgs = append(chezmoiApplyCmdArgs, c.chezmoiConfig.githubUsername)
 
 	var discardOutputOption utils.Option = utils.EmptyOption()

--- a/installer/lib/dotfilesmanager/chezmoi/data.go
+++ b/installer/lib/dotfilesmanager/chezmoi/data.go
@@ -55,8 +55,6 @@ func (c *ChezmoiManager) Initialize(data dotfilesmanager.DotfilesData) error {
 
 	data.SystemData.MapValue(func(value dotfilesmanager.DotfilesSystemData) dotfilesmanager.DotfilesSystemData {
 		viperObject.Set("data.system.shell", value.Shell)
-		viperObject.Set("data.system.multi_user_system", value.MultiUserSystem)
-		viperObject.Set("data.system.brew_multi_user", value.BrewMultiUser)
 
 		if value.GenericWorkProfile.IsPresent() {
 			viperObject.Set("data.system.work_generic_dotfiles_profile", value.GenericWorkProfile)

--- a/installer/lib/dotfilesmanager/chezmoi/data_test.go
+++ b/installer/lib/dotfilesmanager/chezmoi/data_test.go
@@ -281,9 +281,7 @@ func Test_Initialize_WritesSystemData_WhenProvided(t *testing.T) {
 	manager := chezmoi.NewChezmoiManager(logger.DefaultLogger, fileSystem, mockUserManager, mockCommander, mockPackageManager, mockHTTPClient, utils.DisplayModeProgress, config)
 
 	systemData := dotfilesmanager.DotfilesSystemData{
-		Shell:           "/bin/zsh",
-		MultiUserSystem: true,
-		BrewMultiUser:   "multifoo",
+		Shell: "/bin/zsh",
 	}
 	data := dotfilesmanager.DotfilesData{
 		Email:         "test@example.com",
@@ -303,9 +301,6 @@ func Test_Initialize_WritesSystemData_WhenProvided(t *testing.T) {
 	require.NoError(t, err)
 	configStr := string(configContent)
 	require.Contains(t, configStr, "/bin/zsh")
-	require.Contains(t, configStr, "multi_user_system = true")
-	require.Contains(t, configStr, "brew_multi_user")
-	require.Contains(t, configStr, "multifoo")
 }
 
 func Test_Initialize_WritesCompleteData_WhenAllFieldsProvided(t *testing.T) {
@@ -336,8 +331,6 @@ func Test_Initialize_WritesCompleteData_WhenAllFieldsProvided(t *testing.T) {
 	}
 	systemData := dotfilesmanager.DotfilesSystemData{
 		Shell:               "/bin/zsh",
-		MultiUserSystem:     true,
-		BrewMultiUser:       "multifoo",
 		GenericWorkProfile:  mo.Some(path.Join("/home", "user", ".work", "profile")),
 		SpecificWorkProfile: mo.Some(path.Join("/home", "user", ".work", "foobar", "profile")),
 	}
@@ -365,7 +358,4 @@ func Test_Initialize_WritesCompleteData_WhenAllFieldsProvided(t *testing.T) {
 	require.Contains(t, configStr, "Acme Corp")
 	require.Contains(t, configStr, "john.doe@acme.com")
 	require.Contains(t, configStr, "/bin/zsh")
-	require.Contains(t, configStr, "multi_user_system = true")
-	require.Contains(t, configStr, "brew_multi_user")
-	require.Contains(t, configStr, "multifoo")
 }

--- a/installer/lib/dotfilesmanager/chezmoi/manager.go
+++ b/installer/lib/dotfilesmanager/chezmoi/manager.go
@@ -20,15 +20,17 @@ type ChezmoiConfig struct {
 	chezmoiCloneDir       string
 	githubUsername        string
 	cloneViaSSH           bool
+	branch                string
 }
 
-func NewChezmoiConfig(configDir, configFilePath, cloneDir, githubUsername string, cloneViaSSH bool) ChezmoiConfig {
+func NewChezmoiConfig(configDir, configFilePath, cloneDir, githubUsername string, cloneViaSSH bool, branch string) ChezmoiConfig {
 	return ChezmoiConfig{
 		chezmoiConfigDir:      configDir,
 		chezmoiConfigFilePath: configFilePath,
 		chezmoiCloneDir:       cloneDir,
 		githubUsername:        githubUsername,
 		cloneViaSSH:           cloneViaSSH,
+		branch:                branch,
 	}
 }
 
@@ -39,6 +41,7 @@ func DefaultChezmoiConfig(chezmoiConfigFilePath string, chezmoiCloneDir string) 
 		chezmoiCloneDir:       chezmoiCloneDir,
 		githubUsername:        "MrPointer",
 		cloneViaSSH:           false,
+		branch:                "",
 	}
 }
 
@@ -68,7 +71,7 @@ func NewChezmoiManager(logger logger.Logger, filesystem utils.FileSystem, userMa
 	}
 }
 
-func TryStandardChezmoiManager(logger logger.Logger, filesystem utils.FileSystem, userManager osmanager.UserManager, commander utils.Commander, pkgManager pkgmanager.PackageManager, httpClient httpclient.HTTPClient, displayMode utils.DisplayMode, githubUsername string, cloneViaSSH bool) (*ChezmoiManager, error) {
+func TryStandardChezmoiManager(logger logger.Logger, filesystem utils.FileSystem, userManager osmanager.UserManager, commander utils.Commander, pkgManager pkgmanager.PackageManager, httpClient httpclient.HTTPClient, displayMode utils.DisplayMode, githubUsername string, cloneViaSSH bool, branch string) (*ChezmoiManager, error) {
 	chezmoiConfigHome, err := userManager.GetChezmoiConfigHome()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chezmoi config home directory: %w", err)
@@ -97,10 +100,11 @@ func TryStandardChezmoiManager(logger logger.Logger, filesystem utils.FileSystem
 			chezmoiCloneDir,
 			githubUsername,
 			cloneViaSSH,
+			branch,
 		),
 	), nil
 }
 
 func TryStandardChezmoiManagerWithDefaults(logger logger.Logger, filesystem utils.FileSystem, userManager osmanager.UserManager, commander utils.Commander, pkgManager pkgmanager.PackageManager, httpClient httpclient.HTTPClient, displayMode utils.DisplayMode) (*ChezmoiManager, error) {
-	return TryStandardChezmoiManager(logger, filesystem, userManager, commander, pkgManager, httpClient, displayMode, DefaultGitHubUsername, false)
+	return TryStandardChezmoiManager(logger, filesystem, userManager, commander, pkgManager, httpClient, displayMode, DefaultGitHubUsername, false, "")
 }

--- a/installer/lib/dotfilesmanager/data.go
+++ b/installer/lib/dotfilesmanager/data.go
@@ -20,8 +20,6 @@ type DotfilesWorkEnvData struct {
 
 type DotfilesSystemData struct {
 	Shell               string            `mapstructure:"shell"`
-	MultiUserSystem     bool              `mapstructure:"multi_user_system"`
-	BrewMultiUser       string            `mapstructure:"brew_multi_user"`
 	GenericWorkProfile  mo.Option[string] `mapstructure:"generic_work_profile"`
 	SpecificWorkProfile mo.Option[string] `mapstructure:"specific_work_profile"`
 }

--- a/installer/test-interactive-gpg.exp
+++ b/installer/test-interactive-gpg.exp
@@ -1,7 +1,7 @@
 #!/usr/bin/expect -f
 #
 # Interactive GPG Testing Script for Dotfiles Installer
-# Usage: ./test-interactive-gpg.exp [installer_path] [email] [name] [passphrase]
+# Usage: ./test-interactive-gpg.exp [installer_path] [email] [name] [passphrase] [branch]
 #
 # This script automates GPG key setup during interactive installation
 # for both CI testing and local development.
@@ -14,7 +14,8 @@ set installer_path [lindex $argv 0]
 set email [lindex $argv 1]
 set name [lindex $argv 2]
 set passphrase [lindex $argv 3]
-set verbosity [lindex $argv 4]
+set branch [lindex $argv 4]
+set verbosity [lindex $argv 5]
 
 # Use defaults if not provided
 if {$installer_path eq ""} {
@@ -28,6 +29,9 @@ if {$name eq ""} {
 }
 if {$passphrase eq ""} {
     set passphrase "test-ci-passphrase"
+}
+if {$branch eq ""} {
+    set branch ""
 }
 if {$verbosity eq ""} {
     set verbosity ""
@@ -45,10 +49,20 @@ puts "  Installer: $installer_path"
 puts "  Email: $email"
 puts "  Name: $name"
 puts "  Passphrase: [string repeat "*" [string length $passphrase]]"
+puts "  Branch: $branch"
 puts "  Verbosity: $verbosity"
 puts ""
 
-spawn $installer_path install --plain --install-prerequisites=true --git-clone-protocol=https "$verbosity"
+# Build command with optional branch parameter
+set cmd_args [list "install" "--plain" "--install-prerequisites=true" "--git-clone-protocol=https"]
+if {$branch ne ""} {
+    lappend cmd_args "--git-branch=$branch"
+}
+if {$verbosity ne ""} {
+    lappend cmd_args $verbosity
+}
+
+spawn $installer_path {*}$cmd_args
 
 # Main interaction loop - Only handle GPG-specific prompts
 expect {


### PR DESCRIPTION
## Summary

This PR removes multi-user support, especially for brew installations.
It never really worked in practice, so this just adds complexity and noise at this stage. Now that our installer is fully compliant with the depracted shell installer, we have no need for the mutli-user support.

This PR also adds an important ability to apply dotfiles for a custom branch.
This is mainly used by CI to run E2E tests using the currently tested branch to ensure full compatibility.