### PR TITLE
Add CI gate job for auto-merge support

### DIFF
--- a/.github/workflows/installer-ci.yml
+++ b/.github/workflows/installer-ci.yml
@@ -354,3 +354,28 @@ jobs:
             echo "No .zshenv found (expected if chezmoi apply was skipped)"
             zsh -c 'echo "zsh works correctly"'
           fi
+
+  # Gate job for auto-merge: always runs, reports the aggregate result of all CI jobs.
+  # When the workflow is skipped entirely (no installer/** changes), GitHub treats the
+  # check as "pending" which won't block merging in rulesets. When it does run, it
+  # accurately reflects whether build/test/e2e passed.
+  ci-status:
+    name: Installer CI Status
+    if: always()
+    needs: [build, test, e2e-test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        run: |
+          echo "build: ${{ needs.build.result }}"
+          echo "test: ${{ needs.test.result }}"
+          echo "e2e-test: ${{ needs.e2e-test.result }}"
+
+          if [[ "${{ needs.build.result }}" == "failure" || \
+                "${{ needs.test.result }}" == "failure" || \
+                "${{ needs.e2e-test.result }}" == "failure" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          fi
+
+          echo "All jobs passed (or were skipped/cancelled)"


### PR DESCRIPTION
Adds an `Installer CI Status` gate job to the installer CI workflow. This job:

- Runs with `if: always()` so it always reports a status
- Checks the results of `build`, `test`, and `e2e-test`
- Fails only if any of those jobs actually failed
- Passes if they succeeded, were skipped, or were cancelled

A matching `require-installer-ci` ruleset has been created on the repo requiring this check. This enables auto-merge:

- **Installer PRs**: CI runs, gate job waits for results, auto-merge proceeds on pass
- **Dotfiles-only PRs**: workflow is skipped entirely, check stays pending (not blocking in rulesets), auto-merge proceeds immediately